### PR TITLE
Add support for UTF-8 with BOM encoding.

### DIFF
--- a/Superlime.py
+++ b/Superlime.py
@@ -34,6 +34,7 @@ class Superlime(sublime_plugin.EventListener):
 						.replace("Mac ", "mac") \
 						.replace("KOI8-", "koi8_") \
 						.replace("UTF-16 ", "utf_16_") \
+						.replace("UTF-8 with BOM", "utf_8_sig") \
 						.replace("UTF-8 ", "utf_8") \
 						.lower()
 			try:


### PR DESCRIPTION
This change allows saving files encoded as "UTF-8 with BOM". Previously an error would appear in the console stating that there was a `LookupError: unknown encoding: utf_8with bom`

